### PR TITLE
feat: PersistenceManager 코드, mainContext 주입 코드 구현

### DIFF
--- a/Retrospective/Core/Storage/SwiftData/PersistenceManager.swift
+++ b/Retrospective/Core/Storage/SwiftData/PersistenceManager.swift
@@ -1,0 +1,65 @@
+//
+//  PersistenceManager.swift
+//  SwiftDataExample
+//
+//  Created by 김건우 on 5/12/25.
+//
+
+import SwiftData
+
+@MainActor
+final class PersistenceManager {
+
+    /// 모델 데이터를 가져오거나, 수정하거나 삭제할 수 있는 메인 컨텍스트 객체입니다.
+    /// - Note: 이 컨텍스트는 ModelContainer의 기본 컨텍스트로,
+    ///   모든 데이터 작업은 이 컨텍스트를 통해 수행됩니다.
+    var mainContext: ModelContext {
+        container.mainContext
+    }
+
+    private let container: ModelContainer = {
+        let schema = Schema([
+            Item.self
+        ])
+        let modelConfiguration = ModelConfiguration(schema: schema)
+
+        do {
+            return try ModelContainer(
+                for: schema,
+                configurations: [modelConfiguration]
+            )
+        } catch {
+            fatalError(error.localizedDescription)
+        }
+    }()
+}
+
+extension PersistenceManager {
+    
+    /// 프리뷰 환경에서만 사용되는 ModelContainer 객체입니다.
+    /// 이 컨테이너는 메모리에만 저장되는 임시 컨테이너입니다.
+    /// - Note: 각 모델에 대한 Mock 데이터가 포함되어 있어,
+    /// Preview에서 실제 데이터 없이도 UI를 미리볼 수 있습니다.
+    static let previewContainer: ModelContainer = {
+        let schema = Schema([
+            Item.self
+        ])
+        let modelConfiguration = ModelConfiguration(
+            schema: schema,
+            isStoredInMemoryOnly: true
+        )
+
+        do {
+            let container = try ModelContainer(
+                for: schema,
+                configurations: [modelConfiguration]
+            )
+
+            Item.mock.forEach(container.mainContext.insert(_:))
+
+            return container
+        } catch {
+            fatalError(error.localizedDescription)
+        }
+    }()
+}

--- a/Retrospective/Models/Item.swift
+++ b/Retrospective/Models/Item.swift
@@ -1,0 +1,35 @@
+//
+//  Item.swift
+//  SwiftDataExample
+//
+//  Created by 김건우 on 5/12/25.
+//
+
+import Foundation
+import SwiftData
+
+@Model
+final class Item {
+    var timestamp: Date
+
+    init(timestamp: Date) {
+        self.timestamp = timestamp
+    }
+}
+
+extension Item {
+
+    static let mock: [Item] = [
+        .init(timestamp: Date()),
+        .init(timestamp: Date(timeIntervalSinceNow: -1)),
+        .init(timestamp: Date(timeIntervalSinceNow: -2)),
+        .init(timestamp: Date(timeIntervalSinceNow: -3)),
+        .init(timestamp: Date(timeIntervalSinceNow: -4)),
+        .init(timestamp: Date(timeIntervalSinceNow: -5)),
+        .init(timestamp: Date(timeIntervalSinceNow: -6)),
+        .init(timestamp: Date(timeIntervalSinceNow: -7)),
+        .init(timestamp: Date(timeIntervalSinceNow: -8)),
+        .init(timestamp: Date(timeIntervalSinceNow: -9)),
+        .init(timestamp: Date(timeIntervalSinceNow: -10)),
+    ]
+}

--- a/Retrospective/Models/Model.swift
+++ b/Retrospective/Models/Model.swift
@@ -1,8 +1,0 @@
-//
-//  Model.swift
-//  Retrospective
-//
-//  Created by 김건우 on 5/11/25.
-//
-
-import Foundation

--- a/Retrospective/RetrospectiveApp.swift
+++ b/Retrospective/RetrospectiveApp.swift
@@ -6,12 +6,16 @@
 //
 
 import SwiftUI
+import SwiftData
 
 @main
 struct RetrospectiveApp: App {
+    let persistenceManager = PersistenceManager()
+
     var body: some Scene {
         WindowGroup {
             ContentView()
         }
+        .modelContext(persistenceManager.mainContext)
     }
 }

--- a/Retrospective/Utils/Extesnions/ModelContext+Extension.swift
+++ b/Retrospective/Utils/Extesnions/ModelContext+Extension.swift
@@ -1,0 +1,38 @@
+//
+//  ModelContext+Extension.swift
+//  SwiftDataExample
+//
+//  Created by 김건우 on 5/12/25.
+//
+
+import SwiftData
+
+extension ModelContext {
+    
+    /// mainContext에 모델을 추가한 후, 곧바로 저장합니다.
+    ///
+    /// - Note: 저장에 실패할 경우, 디버그 콘솔에 오류 로그가 출력되며, 크래시는 일어나지 않습니다.
+    /// - Parameter model: 저장할 모델 객체
+    func insert<T>(andSave model: T) where T: PersistentModel {
+        insert(model)
+        saveChanges()
+    }
+
+    /// mainContext에 모델을 삭제한 후, 곧바로 저장합니다.
+    ///
+    /// - Note: 저장에 실패할 경우, 디버그 콘솔에 오류 로그가 출력되며, 크래시는 일어나지 않습니다.
+    /// - Parameter model: 삭제할 모델 객체
+    func delete<T>(andSave model: T) where T: PersistentModel {
+        delete(model)
+        saveChanges()
+    }
+
+    private func saveChanges() {
+        do {
+            try save()
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+}
+

--- a/Retrospective/Utils/Extesnions/String+Extension.swift
+++ b/Retrospective/Utils/Extesnions/String+Extension.swift
@@ -1,8 +1,0 @@
-//
-//  String+Extension.swift
-//  Retrospective
-//
-//  Created by 김건우 on 5/11/25.
-//
-
-import Foundation


### PR DESCRIPTION
## #️⃣ Related Issues

close #8 

## 📝 Task Details

* 임시 모델 데이터 `Item` 구현
    - `Item` 모델은 임시 모델이므로, 실사용 시 다른 모델로 교체해 사용하세요!

* SwiftData의 ModelContainer 및 MainContext 생성을 도와주는 `PersistenceManager` 코드 구현

* ModelContext+Extension에 `insert(andSave)`, `delete(andSave:)` 메서드 구현
    -  `insert(andSave)`, `delete(andSave:)` 메서드는 해당 ModelContext에서 모델을 추가 및 삭제를 하고, 곧바로 저장(save)합니다.
    - 매번 데이터를 변경을 가할 때마다, 컨텍스트가 자동으로 저장되게 하려고 작성하게 되었습니다. 