### PR TITLE
feat: FloatingSheet 공통 코드 구현, `cornerRadius`, `defaultShadow` 확장 메서드 구현

### DIFF
--- a/Retrospective/Core/FloatingSheet/Extensions/View+FloatingSheet.swift
+++ b/Retrospective/Core/FloatingSheet/Extensions/View+FloatingSheet.swift
@@ -1,0 +1,27 @@
+//
+//  View+FloatingSheet.swift
+//  Retrospective
+//
+//  Created by 김건우 on 5/12/25.
+//
+
+import SwiftUI
+
+extension View {
+
+    func floatingSheet<Content>(
+        isPresented: Binding<Bool>,
+        onDismiss: (() -> Void)? = nil,
+        @ViewBuilder content: @escaping () -> Content
+    ) -> some View where Content: View {
+        ZStack {
+            self
+            FloatingSheet(
+                isPresented: isPresented,
+                onDismiss: onDismiss,
+                content: content
+            )
+        }
+    }
+
+}

--- a/Retrospective/Core/FloatingSheet/Extensions/View+FloatingSheet.swift
+++ b/Retrospective/Core/FloatingSheet/Extensions/View+FloatingSheet.swift
@@ -9,6 +9,12 @@ import SwiftUI
 
 extension View {
 
+    /// 지정된 조건에 따라 플로팅 시트를 화면에 표시하는 뷰 모디파이어입니다.
+    /// - Parameters:
+    ///   - isPresented: 시트가 표시될지 여부를 나타내는 바인딩 값입니다.
+    ///   - onDismiss: 시트가 닫힐 때 호출되는 클로저입니다.
+    ///   - content: 시트에 표시할 콘텐츠를 제공하는 클로저입니다.
+    /// - Returns: 플로팅 시트가 적용된 뷰를 반환합니다.
     func floatingSheet<Content>(
         isPresented: Binding<Bool>,
         onDismiss: (() -> Void)? = nil,
@@ -23,5 +29,4 @@ extension View {
             )
         }
     }
-
 }

--- a/Retrospective/Core/FloatingSheet/FloatingSheet.swift
+++ b/Retrospective/Core/FloatingSheet/FloatingSheet.swift
@@ -9,29 +9,31 @@ import SwiftUI
 
 struct FloatingSheet<Content>: View where Content: View {
 
-    ///
+    /// 사용자가 드래그할 때, 처음 드래그 위치와 이후 드래그 위치의 차이를 저장하는 상태 변수입니다.
     @State private var dragOffsetX: CGFloat = 0.0
     @State private var dragOffsetY: CGFloat = 0.0
-    ///
+    /// 드래그 동작 중 최초 드래그 정보를 저장하는 상태 변수입니다.
     @State private var previousGesture: DragGesture.Value?
-    ///
+    /// 현재 사용자가 드래그 중인지 여부를 나타내는 상태 변수입니다.
     @State private var isDragging: Bool = false
 
-    ///
+    /// 플로팅 시트가 표시되는 상태를 제어하는 바인딩 값입니다.
     @Binding var isPresented: Bool
+    /// 시트가 닫힐 때 실행할 클로저
     private let onDismiss: (() -> Void)?
     private let content: Content
 
-    ///
+    /// 플로팅 시트의 모서리 반경을 지정하는 상수입니다.
     private let cornerRadius: Double = 24
-    ///
+    /// 플로팅 시트의 애니메이션 지속 시간을 지정하는 상수입니다.
     private let animationDuration: Double = 0.25
 
 
-    /// <#Description#>
+    /// 플로팅 시트를 초기화하는 생성자입니다.
     /// - Parameters:
-    ///   - isPresented: <#isPresented description#>
-    ///   - content: <#content description#>
+    ///   - isPresented: 시트의 표시 여부를 제어하는 바인딩 값입니다.
+    ///   - onDismiss: 시트가 닫힐 때 실행할 클로저입니다.
+    ///   - content: 시트에 표시할 콘텐츠를 제공하는 클로저입니다.
     init(
         isPresented: Binding<Bool>,
         onDismiss: (() -> Void)? = nil,
@@ -51,7 +53,7 @@ struct FloatingSheet<Content>: View where Content: View {
                     .cornerRadius(.background, radius: cornerRadius)
                     .background {
                         RoundedRectangle(cornerRadius: cornerRadius)
-                            .shadow(radius: 8, x: 3, y: 3)
+                            .defaultShadow()
                     }
                     .transition(
                         .asymmetric(

--- a/Retrospective/Core/FloatingSheet/FloatingSheet.swift
+++ b/Retrospective/Core/FloatingSheet/FloatingSheet.swift
@@ -1,0 +1,187 @@
+//
+//  FloatingSheet.swift
+//  Retrospective
+//
+//  Created by 김건우 on 5/12/25.
+//
+
+import SwiftUI
+
+struct FloatingSheet<Content>: View where Content: View {
+
+    ///
+    @State private var dragOffsetX: CGFloat = 0.0
+    @State private var dragOffsetY: CGFloat = 0.0
+    ///
+    @State private var previousGesture: DragGesture.Value?
+    ///
+    @State private var isDragging: Bool = false
+
+    ///
+    @Binding var isPresented: Bool
+    private let onDismiss: (() -> Void)?
+    private let content: Content
+
+    ///
+    private let cornerRadius: Double = 24
+    ///
+    private let animationDuration: Double = 0.25
+
+
+    /// <#Description#>
+    /// - Parameters:
+    ///   - isPresented: <#isPresented description#>
+    ///   - content: <#content description#>
+    init(
+        isPresented: Binding<Bool>,
+        onDismiss: (() -> Void)? = nil,
+        content: () -> Content
+    ) {
+        self._isPresented = isPresented
+        self.onDismiss = onDismiss
+        self.content = content()
+    }
+
+    var body: some View {
+        ZStack {
+            if isPresented {
+                content
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .cornerRadius(.background, radius: cornerRadius)
+                    .background {
+                        RoundedRectangle(cornerRadius: cornerRadius)
+                            .shadow(radius: 8, x: 3, y: 3)
+                    }
+                    .transition(
+                        .asymmetric(
+                            insertion: .move(edge: .bottom),
+                            removal: .move(edge: .bottom)
+                        )
+                    )
+                    .padding()
+                    .safeAreaPadding(.bottom)
+                    .offset(x: dragOffsetX, y: dragOffsetY)
+                    .scaleEffect(isDragging ? CGSize(width: 0.95, height: 0.95) : CGSize(width: 1.0, height: 1.0))
+                    .animation(.smooth(duration: animationDuration), value: dragOffsetX)
+                    .animation(.smooth(duration: animationDuration), value: dragOffsetY)
+                    .animation(.smooth(duration: animationDuration), value: isDragging)
+                    .gesture(dragGesture())
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+        .background {
+            if isPresented {
+                // 플로팅 시트의 백그라운드 뷰(색상)
+                Color.gray.opacity(0.55)
+                    .onTapGesture { dismiss() }
+            }
+        }
+        .animation(.smooth(duration: animationDuration), value: isPresented)
+        .ignoresSafeArea()
+    }
+}
+
+extension FloatingSheet {
+
+    private func dragGesture() -> some Gesture {
+        DragGesture(minimumDistance: 10, coordinateSpace: .global)
+            .onChanged(onChanged)
+            .onEnded(onEnded)
+    }
+
+    private func onChanged(_ gesture: DragGesture.Value) {
+        guard let previous = previousGesture else {
+            self.previousGesture = gesture
+            return
+        }
+
+        // 위로 드래그하면 offsetY가 음수(-)가 되고,
+        // 아래로 드래그하면 offsetY가 양수(+)가 됩니다.
+        let offsetY = gesture.location.y - previous.location.y
+        let offsetX = gesture.location.x - previous.location.x
+
+        if offsetY > 0 {
+            dragOffsetY = offsetY
+        } else {
+            dragOffsetY = offsetY * 0.1
+        }
+        dragOffsetX = offsetX * 0.1
+        isDragging = true
+    }
+
+    private func onEnded(_ value: DragGesture.Value) {
+        if dragOffsetY > 20 {
+            dismiss()
+            // 뷰가 사라지는 동안 scaleEffect 효과를 유지합니다.
+            // 일정 시간이 지난 후(scale 효과가 적용된 상태 유지), scaleEffect를 원래 상태로 복원합니다.
+            Task.delayed(byTimeInterval: 0.25) { @MainActor in
+                isDragging = false
+            }
+        } else {
+            reset()
+        }
+    }
+
+    private func reset() {
+        dragOffsetX = 0
+        dragOffsetY = 0
+        previousGesture = nil
+        isDragging = false
+    }
+
+    private func dismiss() {
+        isPresented = false
+        dragOffsetX = 0
+        dragOffsetY = 0
+        previousGesture = nil
+
+        onDismiss?()
+    }
+}
+
+#Preview {
+    @Previewable @State var isPresented: Bool = true
+    FloatingSheet(isPresented: $isPresented) {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Marget Caplitalization")
+                .font(.title2)
+                .fontWeight(.bold)
+
+            Text("As of February 3rd, US Time")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+
+            VStack {
+                Text("Stock Price X Shares Outstanding")
+                    .font(.headline)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.horizontal)
+            .padding(.vertical, 16)
+            .cornerRadius(Color(UIColor.systemGray6), radius: 16)
+            .padding(.top, 24)
+
+            Text("Market capitalization represents the total value of a company's stock. It helps compare the size of companies in the stock market")
+                .font(.footnote)
+                .fontWeight(.semibold)
+                .padding(.top, 24)
+
+            Button { }
+            label: {
+                Text("Confirm")
+                    .fontWeight(.bold)
+                    .foregroundStyle(.white)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+            .cornerRadius(.blue, radius: 14)
+            .padding(.top, 12)
+
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 4)
+        .padding(.horizontal, 4)
+    }
+}

--- a/Retrospective/Utils/Extesnions/Task+Extension.swift
+++ b/Retrospective/Utils/Extesnions/Task+Extension.swift
@@ -9,17 +9,17 @@ import Foundation
 
 extension Task where Error == Failure {
     
-    /// <#Description#>
+    /// 지정된 시간 후에 비동기 작업을 지연 실행하는 함수입니다.
     /// - Parameters:
-    ///   - timeInterval: <#timeInterval description#>
-    ///   - priority: <#priority description#>
-    ///   - operation: <#operation description#>
+    ///   - timeInterval: 작업을 지연시킬 시간입니다. (초 단위)
+    ///   - priority: 작업의 우선 순위입니다.
+    ///   - operation: 지정된 시간이 경과한 후 실행할 비동기 작업입니다.
     static func delayed(
         byTimeInterval timeInterval: TimeInterval,
         priority: TaskPriority? = nil,
         @_implicitSelfCapture operation: @Sendable @escaping @isolated(any) () async throws -> Success
     ) {
-        Task {
+       Task {
             let seconds = UInt64(timeInterval * 1_000_000_000)
             try await Task<Never, Never>.sleep(nanoseconds: seconds)
             return try await operation()

--- a/Retrospective/Utils/Extesnions/Task+Extension.swift
+++ b/Retrospective/Utils/Extesnions/Task+Extension.swift
@@ -1,0 +1,28 @@
+//
+//  Task+Extension.swift
+//  Retrospective
+//
+//  Created by 김건우 on 5/12/25.
+//
+
+import Foundation
+
+extension Task where Error == Failure {
+    
+    /// <#Description#>
+    /// - Parameters:
+    ///   - timeInterval: <#timeInterval description#>
+    ///   - priority: <#priority description#>
+    ///   - operation: <#operation description#>
+    static func delayed(
+        byTimeInterval timeInterval: TimeInterval,
+        priority: TaskPriority? = nil,
+        @_implicitSelfCapture operation: @Sendable @escaping @isolated(any) () async throws -> Success
+    ) {
+        Task {
+            let seconds = UInt64(timeInterval * 1_000_000_000)
+            try await Task<Never, Never>.sleep(nanoseconds: seconds)
+            return try await operation()
+        }
+    }
+}

--- a/Retrospective/Utils/Extesnions/View+Extension.swift
+++ b/Retrospective/Utils/Extesnions/View+Extension.swift
@@ -9,13 +9,34 @@ import SwiftUI
 
 extension View {
 
-    /// <#Description#>
+    /// 지정된 스타일과 모서리 반경을 적용하여 뷰의 배경을 둥글게 처리하는 메서드입니다.
     /// - Parameters:
-    ///   - style: <#style description#>
-    ///   - radius: <#radius description#>
-    /// - Returns: <#description#>
-    /// - Important: 공통 radius 값은 아직 정해지지 않았습니다. 정해지는대로 기본 매개변수 값을 수정해주세요!
+    ///   - style: 배경으로 사용할 스타일
+    ///   - radius: 둥글게 처리할 모서리의 반경 (기본값: 24)
+    /// - Returns: 지정된 스타일과 모서리 반경이 적용된 뷰를 반환합니다.
+    ///
+    /// - Important: 공통 radius 값은 아직 정해지지 않았습니다.
+    /// 정해지는대로 기본 매개변수 값을 수정해주세요!
     func cornerRadius(_ style: some ShapeStyle, radius: CGFloat = 24) -> some View {
         background(style, in: RoundedRectangle(cornerRadius: radius))
+    }
+    
+    /// 지정된 색상과 위치로 그림자 효과를 적용하는 메서드입니다.
+    /// - Parameters:
+    ///   - color: 그림자의 색상 (기본값: 검정색 33% 불투명도)
+    ///   - radius: 그림자의 블러 반경 (기본값: 8)
+    ///   - x: 그림자의 X축 오프셋 (기본값: 5)
+    ///   - y: 그림자의 Y축 오프셋 (기본값: 5)
+    /// - Returns: 지정된 색상과 위치로 그림자 효과가 적용된 뷰를 반환합니다.
+    ///
+    /// - Important: 공통 color 값은 아직 정해지지 않았습니다.
+    /// 정해지는대로 기본 매개변수 값을 수정해주세요!
+    func defaultShadow(
+        _ color: Color = .black.opacity(0.33),
+        radius: CGFloat = 8,
+        x: CGFloat = 5,
+        y: CGFloat = 5
+    ) -> some View {
+        shadow(color: color, radius: radius, x: x, y: y)
     }
 }

--- a/Retrospective/Utils/Extesnions/View+Extension.swift
+++ b/Retrospective/Utils/Extesnions/View+Extension.swift
@@ -1,0 +1,21 @@
+//
+//  View+Extension.swift
+//  Retrospective
+//
+//  Created by 김건우 on 5/12/25.
+//
+
+import SwiftUI
+
+extension View {
+
+    /// <#Description#>
+    /// - Parameters:
+    ///   - style: <#style description#>
+    ///   - radius: <#radius description#>
+    /// - Returns: <#description#>
+    /// - Important: 공통 radius 값은 아직 정해지지 않았습니다. 정해지는대로 기본 매개변수 값을 수정해주세요!
+    func cornerRadius(_ style: some ShapeStyle, radius: CGFloat = 24) -> some View {
+        background(style, in: RoundedRectangle(cornerRadius: radius))
+    }
+}

--- a/Retrospective/Views/ContentView.swift
+++ b/Retrospective/Views/ContentView.swift
@@ -8,14 +8,57 @@
 import SwiftUI
 
 struct ContentView: View {
+    @State private var isPresented: Bool = false
+
     var body: some View {
         VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+            Button("FloatingSheet") {
+                isPresented.toggle()
+            }
         }
         .padding()
+        .floatingSheet(isPresented: $isPresented, onDismiss: { print("dismissed") }) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Marget Caplitalization")
+                    .font(.title2)
+                    .fontWeight(.bold)
+
+                Text("As of February 3rd, US Time")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+
+                VStack {
+                    Text("Stock Price * Shares Outstanding")
+                        .font(.headline)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.horizontal)
+                .padding(.vertical, 16)
+                .cornerRadius(Color(UIColor.systemGray6), radius: 16)
+                .padding(.top, 24)
+
+                Text("Market capitalization represents the total value of a company's stock. It helps compare the size of companies in the stock market")
+                    .font(.footnote)
+                    .fontWeight(.semibold)
+                    .padding(.top, 24)
+
+                Button { }
+                label: {
+                    Text("Confirm")
+                        .fontWeight(.bold)
+                        .foregroundStyle(.white)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 14)
+                .cornerRadius(.blue, radius: 14)
+                .padding(.top, 12)
+
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 4)
+            .padding(.horizontal, 4)
+        }
     }
 }
 


### PR DESCRIPTION
## #️⃣ Related Issues

close #11 

## 📝 Task Details

#### `FloatingSheet` 공통 코드 구현

* 시트를 붕 뜨게 만들어주는 `FloatingSheet`를 구현했습니다.

```swift
@State private var isPresented: Bool = false

var body: some View {
    VStack {
        Button("FloatingSheet") {
            isPresented.toggle()
        }
    }
    .floatingSheet(isPresented: $isPresented) {
         Text("Marget Caplitalization")
    }
}
```

* 플로팅 시트(FloatingSheet)를 띄우려면 `floatingSheet(isPresented:)` 메소드를 호출하세요. API 사용 방법은 기존 Sheet와 동일합니다!

#### `cornerRadius`, `defaultShadow` 확장 메서드 구현

```swift
RoundedRectangle(cornerRadius: cornerRadius)
    .defaultShadow()

content
    .cornerRadius(.background, radius: cornerRadius)
```

* 프로젝트 공통으로 사용되는 `defaultShadow`와 `cornerRadius` 메서드를 구현했습니다. 
    - 매개변수 기본 값에 임시 값을 넣어두었습니다. 나중에 회의를 통해 바꿔봐요. 

### Screenshot (Optional)

![Simulator Screenshot - iPhone 16 Pro - 2025-05-12 at 14 59 53](https://github.com/user-attachments/assets/2626b556-0cfa-482d-863b-bbac07a40dab)

![Simulator Screen Recording - iPhone 16 Pro - 2025-05-12 at 15 00 16](https://github.com/user-attachments/assets/1a445f10-225c-471c-b84b-b752ede2e428)
