### PR TITLE
feat: 분석 기간(범위) 지정을 위한 날짜(Date) 확장 메서드 구현, RetrospectiveNavigationStack의 네비게이션 바의 색상 변경 API 추가 구현

### DIFF
--- a/Retrospective/Core/RetrospectiveNavigationStack/Extensions/View+RetrospectiveNavigationStack.swift
+++ b/Retrospective/Core/RetrospectiveNavigationStack/Extensions/View+RetrospectiveNavigationStack.swift
@@ -46,4 +46,11 @@ extension View {
             value: ToolBarLayout(spacing: spacing, toolBarProvider: AnyView(content()))
         )
     }
+    
+    /// 사용자 지정 내비게이션 바 색상을 설정합니다.
+    /// - Parameter color: 내비게이션 바에 적용할 색상입니다.
+    /// - Returns: 지정된 내비게이션 바 색상 프리퍼런스가 적용된 뷰
+    func retrospectiveNavigationBarColor(_ color: Color) -> some View {
+        self.preference(key: NavigationBarColorPreferenceKey.self, value: color)
+    }
 }

--- a/Retrospective/Core/RetrospectiveNavigationStack/PreferenceKeys/NavigationBarColorPreferenceKey.swift
+++ b/Retrospective/Core/RetrospectiveNavigationStack/PreferenceKeys/NavigationBarColorPreferenceKey.swift
@@ -1,0 +1,16 @@
+//
+//  NavigationBarColorPreferenceKey.swift
+//  Retrospective
+//
+//  Created by 김건우 on 5/13/25.
+//
+
+import SwiftUI
+
+struct NavigationBarColorPreferenceKey: PreferenceKey {
+    static let defaultValue: Color? = nil
+
+    static func reduce(value: inout Color?, nextValue: () -> Color?) {
+        value = nextValue()
+    }
+}

--- a/Retrospective/Core/RetrospectiveNavigationStack/RetrospectiveNavigationStack.swift
+++ b/Retrospective/Core/RetrospectiveNavigationStack/RetrospectiveNavigationStack.swift
@@ -19,6 +19,8 @@ struct RetrospectiveNavigationStack<Root>: View where Root: View {
     @State private var leadingToolbar: ToolBarLayout? = nil
     /// 네비게이션 바의 우측 툴바 레이아웃을 설정합니다.
     @State private var trailingToolbar: ToolBarLayout? = nil
+    /// 사용자 지정 네비게이션 바의 배경색을 설정합니다.
+    @State private var navigationBarColor: Color? = nil
 
     /// 사용자 지정 네비게이션 바 아래에 표시될 루트 콘텐츠 뷰입니다.
     private let root: Root
@@ -47,6 +49,9 @@ struct RetrospectiveNavigationStack<Root>: View where Root: View {
         }
         .onPreferenceChangeMainActor(TrailingToolBarPreferenceKey.self) { toolbar in
             trailingToolbar = toolbar
+        }
+        .onPreferenceChangeMainActor(NavigationBarColorPreferenceKey.self) { color in
+            navigationBarColor = color
         }
     }
 }
@@ -79,7 +84,7 @@ extension RetrospectiveNavigationStack {
         .frame(maxWidth: .infinity)
         .padding(.horizontal)
         .padding(.bottom, 4)
-        .background(.white)
+        .background(navigationBarColor ?? .clear)
 
         Divider()
     }
@@ -119,6 +124,7 @@ extension RetrospectiveNavigationStack {
                 .padding()
         }
         .retrospectiveNavigationTitle("Our Camp Diary")
+        .retrospectiveNavigationBarColor(.appLightPeach)
     }
 }
 

--- a/Retrospective/Utils/Extesnions/Date+Extension.swift
+++ b/Retrospective/Utils/Extesnions/Date+Extension.swift
@@ -1,0 +1,108 @@
+//
+//  Date+Extension.swift
+//  Retrospective
+//
+//  Created by 김건우 on 5/13/25.
+//
+
+import Foundation
+
+extension Date {
+
+    /// 현재 날짜가 속한 주의 시작일과 종료일을 튜플로 반환합니다.
+    /// - Returns: 주의 시작일 (`startOfWeek`)과 종료일 (`endOfWeek`)을 포함하는 튜플
+    var startAndEndOfWeek: (startOfWeek: Date?, endOfWeek: Date?) {
+        (startOfWeek, endOfWeek)
+    }
+
+    /// 현재 날짜가 속한 주의 시작일 (일요일)을 반환합니다.
+    /// - Returns: 주의 시작일 (일요일) 날짜 (Gregorian 캘린더 기준)
+    var startOfWeek: Date? {
+        let gregorian = Calendar(identifier: .gregorian)
+        guard let sunday = gregorian.date(from: gregorian.dateComponents([.yearForWeekOfYear, .weekOfYear], from: self)) else { return nil }
+        return gregorian.date(byAdding: .day, value: 0, to: sunday)
+    }
+
+    /// 현재 날짜가 속한 주의 종료일 (토요일)을 반환합니다.
+    /// - Returns: 주의 종료일 (토요일) 날짜 (Gregorian 캘린더 기준)
+    var endOfWeek: Date? {
+        let gregorian = Calendar(identifier: .gregorian)
+        guard let sunday = gregorian.date(from: gregorian.dateComponents([.yearForWeekOfYear, .weekOfYear], from: self)) else { return nil }
+        return gregorian.date(byAdding: .day, value: 6, to: sunday)
+    }
+
+    /// 현재 날짜에서 7일 뒤의 날짜를 반환합니다.
+    /// - Returns: 현재 날짜로부터 7일 뒤의 날짜
+    var nextWeek: Date? {
+        let gregorian = Calendar(identifier: .gregorian)
+        guard let nextWeek = gregorian.date(byAdding: .day, value: +7, to: self) else { return nil }
+        return nextWeek
+    }
+
+    /// 현재 날짜에서 7일 전의 날짜를 반환합니다.
+    /// - Returns: 현재 날짜로부터 7일 전의 날짜
+    var previousWeek: Date? {
+        let gregorian = Calendar(identifier: .gregorian)
+        guard let previousWeek = gregorian.date(byAdding: .day, value: -7, to: self) else { return nil }
+        return previousWeek
+    }
+}
+
+extension Date {
+
+    /// 현재 날짜에서 다음 달로 이동한 날짜를 반환합니다.
+    /// - Returns: 현재 날짜로부터 정확히 한 달 뒤의 날짜
+    var nextMonth: Date? {
+        let gregorian = Calendar(identifier: .gregorian)
+        guard let nextMonth = gregorian.date(byAdding: .month, value: +1, to: self) else { return nil }
+        return nextMonth
+    }
+
+    /// 현재 날짜에서 이전 달로 이동한 날짜를 반환합니다.
+    /// - Returns: 현재 날짜로부터 정확히 한 달 전의 날짜
+    var previousMonth: Date? {
+        let gregorian = Calendar(identifier: .gregorian)
+        guard let previousMonth = gregorian.date(byAdding: .month, value: -1, to: self) else { return nil }
+        return previousMonth
+    }
+}
+
+extension Date {
+
+    /// 날짜 형식을 정의하는 열거형입니다.
+    enum Format: String {
+        /// 연도와 월을 "yyyy. MM" 형식으로 표현합니다. (예: "2024. 01")
+        case yyyyMM = "yyyy. MM"
+
+        /// 연도, 월, 일을 "yyyy. MM. dd" 형식으로 표현합니다. (예: "2024. 01. 15")
+        case yyyyMMdd = "yyyy. MM. dd"
+
+        /// 월과 연도를 "MMMM yyyy" 형식으로 표현합니다. (예: "January 2024")
+        case MMMMyyyy = "MMMM yyyy"
+
+        /// 일을 "d" 형식으로 표현합니다. (예: "15")
+        case d = "d"
+    }
+
+    /// 지정된 형식으로 날짜를 문자열로 변환합니다.
+    /// - Parameters:
+    ///   - dateFormat: 사용자 지정 날짜 형식 (문자열)
+    ///   - locale: 로케일 (기본값: 영어 (en_us))
+    /// - Returns: 지정된 형식으로 포맷된 날짜 문자열
+    func formatted(_ dateFormat: String, locale: Locale = Locale(identifier: "en_us")) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.timeZone = TimeZone(identifier: "ko_kr")
+        dateFormatter.locale = locale
+        dateFormatter.dateFormat = dateFormat
+        return dateFormatter.string(from: self)
+    }
+
+    /// 지정된 `Format` 열거형 스타일로 날짜를 문자열로 변환합니다.
+    /// - Parameters:
+    ///   - formatStyle: 날짜 형식 스타일 (Format 열거형)
+    ///   - locale: 로케일 (기본값: 영어 (en_us))
+    /// - Returns: 지정된 형식 스타일로 포맷된 날짜 문자열
+    func formatted(_ formatStyle: Format, locale: Locale = Locale(identifier: "en_us")) -> String {
+        formatted(formatStyle.rawValue, locale: locale)
+    }
+}


### PR DESCRIPTION
## #️⃣ Related Issues

close #23 

## 📝 Task Details

#### 날짜 계산 및 포맷을 위한 날짜 확장 메서드 구현

```swift
Date.now.formatted(.MMMMyyyy) // "May 2025"
Date.now.formatted(.yyyyMM) // "2025. 05"
Date.now.formatted(.yyyyMMdd) // "2025. 05. 13"
Date.now.formatted(.d) // "13"
```

* 날짜 포매팅을 도와주는 `formatted(formatStyle:)` 메서드로 날짜를 출력하세요! 원하시는 포맷이 따로 있으시다면 Date.Format 열거형에서 정의해서 사용하세요.

> 이외 정의된 날짜 관련 프로퍼티는 분석 화면 관련 코드라서 설명을 생략하겠습니다~


#### 네비게이션 바 배경 색상 변경 API 추가 구현

```swift
RetrospectiveNavigationStack {
    VStack {
        ForEach(1...10, id: \.self) { _ in
            Text("Hello, RetrospectiveNavigationStack!")
        }
    }
    .retrospectiveNavigationBarColor(.appLightPeach)
}
```

* 네비게이션 바 배경 색상을 변경할 수 있는 `retrospectiveNavigationBarColor(_:)` 메서드가 추가되었습니다. 지정하지 않으면 기본 배경색은 `.clear`가 됩니다.

<img width="514" alt="스크린샷 2025-05-13 오후 1 04 52" src="https://github.com/user-attachments/assets/fbfd3718-a990-4d08-8f31-fd89c65f5d47" />

