### PR TITLE
Feat/#27 bug fix

### DIFF
--- a/Retrospective/Core/FloatingSheet/Extensions/View+FloatingSheet.swift
+++ b/Retrospective/Core/FloatingSheet/Extensions/View+FloatingSheet.swift
@@ -12,11 +12,13 @@ extension View {
     /// 지정된 조건에 따라 플로팅 시트를 화면에 표시하는 뷰 모디파이어입니다.
     /// - Parameters:
     ///   - isPresented: 시트가 표시될지 여부를 나타내는 바인딩 값입니다.
+    ///   - bottomOffset: 시트가 바닥으로부터 떨어져 있는지 나타내는 값입니다.
     ///   - onDismiss: 시트가 닫힐 때 호출되는 클로저입니다.
     ///   - content: 시트에 표시할 콘텐츠를 제공하는 클로저입니다.
     /// - Returns: 플로팅 시트가 적용된 뷰를 반환합니다.
     func floatingSheet<Content>(
         isPresented: Binding<Bool>,
+        bottomOffset: CGFloat = 100,
         onDismiss: (() -> Void)? = nil,
         @ViewBuilder content: @escaping () -> Content
     ) -> some View where Content: View {
@@ -24,6 +26,7 @@ extension View {
             self
             FloatingSheet(
                 isPresented: isPresented,
+                bottomOffset: bottomOffset,
                 onDismiss: onDismiss,
                 content: content
             )

--- a/Retrospective/Core/FloatingSheet/FloatingSheet.swift
+++ b/Retrospective/Core/FloatingSheet/FloatingSheet.swift
@@ -39,7 +39,7 @@ struct FloatingSheet<Content>: View where Content: View {
     ///   - content: 시트에 표시할 콘텐츠를 제공하는 클로저입니다.
     init(
         isPresented: Binding<Bool>,
-        bottomOffset: CGFloat = 10,
+        bottomOffset: CGFloat = 100,
         onDismiss: (() -> Void)? = nil,
         content: () -> Content
     ) {

--- a/Retrospective/Core/FloatingSheet/FloatingSheet.swift
+++ b/Retrospective/Core/FloatingSheet/FloatingSheet.swift
@@ -19,12 +19,14 @@ struct FloatingSheet<Content>: View where Content: View {
 
     /// 플로팅 시트가 표시되는 상태를 제어하는 바인딩 값입니다.
     @Binding var isPresented: Bool
+    /// 플로팅 시트가 바닥으로부터 떨어진 거리 값입니다.
+    private let bottomOffset: CGFloat
     /// 시트가 닫힐 때 실행할 클로저
     private let onDismiss: (() -> Void)?
     private let content: Content
 
     /// 플로팅 시트의 모서리 반경을 지정하는 상수입니다.
-    private let cornerRadius: Double = 24
+    private let cornerRadius: Double = 30
     /// 플로팅 시트의 애니메이션 지속 시간을 지정하는 상수입니다.
     private let animationDuration: Double = 0.25
 
@@ -32,14 +34,17 @@ struct FloatingSheet<Content>: View where Content: View {
     /// 플로팅 시트를 초기화하는 생성자입니다.
     /// - Parameters:
     ///   - isPresented: 시트의 표시 여부를 제어하는 바인딩 값입니다.
+    ///   - bottomOffset: 시트가 바닥으로부터 떨어져 있는지 나타내는 값입니다.
     ///   - onDismiss: 시트가 닫힐 때 실행할 클로저입니다.
     ///   - content: 시트에 표시할 콘텐츠를 제공하는 클로저입니다.
     init(
         isPresented: Binding<Bool>,
+        bottomOffset: CGFloat = 10,
         onDismiss: (() -> Void)? = nil,
         content: () -> Content
     ) {
         self._isPresented = isPresented
+        self.bottomOffset = bottomOffset
         self.onDismiss = onDismiss
         self.content = content()
     }
@@ -62,7 +67,8 @@ struct FloatingSheet<Content>: View where Content: View {
                         )
                     )
                     .padding()
-                    .safeAreaPadding(.bottom)
+                    .padding(.horizontal, 10)
+                    .safeAreaPadding(.bottom, bottomOffset)
                     .offset(x: dragOffsetX, y: dragOffsetY)
                     .scaleEffect(isDragging ? CGSize(width: 0.95, height: 0.95) : CGSize(width: 1.0, height: 1.0))
                     .animation(.smooth(duration: animationDuration), value: dragOffsetX)

--- a/Retrospective/Core/Resources/AppColors.swift
+++ b/Retrospective/Core/Resources/AppColors.swift
@@ -10,22 +10,27 @@ import SwiftUI
 extension ShapeStyle where Self == Color {
 
     /// 주요 글자색
-    /// - Note: 주석 미완성
+    /// - Note: 라이트 모드와 다크 모드에서 시스템 기본 글자색을 사용합니다.
+    /// - Light Mode: 기본 시스템 글자색 (검정 또는 어두운 회색)
+    /// - Dark Mode: 기본 시스템 글자색 (흰색 또는 밝은 회색)
     static var label: Color {
         .init(UIColor.label)
     }
 
     /// 주요 포인트 색 (아이콘, 버튼 border 등)
-    /// - Note: 주석 미완성
+    /// - Light Mode: 밝고 선명한 파란색 (RGB: 66, 143, 222)
+    /// - Dark Mode: 짙은 파란색 (RGB: 44, 98, 173)
     static var appBlue: Color {
         .init(
             light: Color(r: 66.0, g: 143.0, b: 222.0),
-            dark: Color(r: 66.0, g: 143.0, b: 222.0)
+            dark: Color(r: 44.0, g: 98.0, b: 173.0)
         )
     }
 
     /// 전체 앱 배경색 (연한 살색 계열)
-    /// - Note: 주석 미완성
+    /// - Note: 전체 배경색으로 사용되는 색상
+    /// - Light Mode: 연한 살색 (RGB: 247, 232, 212)
+    /// - Dark Mode: 짙은 회색 (RGB: 32, 32, 32)
     static var appLightPeach: Color {
         .init(
             light: Color(r: 247.0, g: 232.0, b: 212.0),
@@ -34,43 +39,46 @@ extension ShapeStyle where Self == Color {
     }
 
     /// 카드 UI의 제목 배경색 (기본 white 혹은 연베이지)
-    /// - Note: 주석 미완성
+    /// - Light Mode: 밝은 하늘색 (RGB: 227, 240, 251)
+    /// - Dark Mode: 짙은 청록색 (RGB: 52, 74, 101)
     static var appSkyBlue: Color {
         .init(
             light: Color(r: 227.0, g: 240.0, b: 251.0),
-            dark: Color(r: 227.0, g: 240.0, b: 251.0)
+            dark: Color(r: 52.0, g: 74.0, b: 101.0)
         )
     }
 
     /// 카드 테두리 등 경계선
-    /// - Note: 주석 미완성
+    /// - Note: 주요 UI 요소에 사용되는 파란색
+    /// - Light Mode: 연한 하늘색 (RGB: 180, 209, 239)
+    /// - Dark Mode: 짙은 청록색 (RGB: 41, 59, 78)
     static var appSkyBlue2: Color {
         .init(
             light: Color(r: 180.0, g: 209.0, b: 239.0),
-            dark: Color(r: 180.0, g: 209.0, b: 239.0)
+            dark: Color(r: 41.0, g: 59.0, b: 78.0)
         )
     }
 
     /// 카드 UI의 배경 (기본 white 혹은 연베이지)
-    /// - Note: 주석 미완성
+    /// - Light Mode: 매우 연한 하늘색 (RGB: 243, 248, 253)
+    /// - Dark Mode: 짙은 블루그레이 (RGB: 30, 40, 54)
     static var appLightSkyBlue: Color {
         .init(
             light: Color(r: 243.0, g: 248.0, b: 253.0),
-            dark: Color(r: 243.0, g: 248.0, b: 253.0)
+            dark: Color(r: 30.0, g: 40.0, b: 54.0)
         )
     }
 
     /// 월/날짜 구분 선 및 글씨색
-    /// - Note: 주석 미완성
+    /// - Light Mode: 밝은 회색 (RGB: 176, 176, 176)
+    /// - Dark Mode: 중간 회색 (RGB: 110, 110, 110)
     static var appLightGray: Color {
         .init(
             light: Color(r: 176.0, g: 176.0, b: 176.0),
-            dark: Color(r: 176.0, g: 176.0, b: 176.0)
+            dark: Color(r: 110.0, g: 110.0, b: 110.0)
         )
     }
 
-    /// 일반 텍스트용 (기본 텍스트)
-    /// - Note: 주석 미완성
     @available(*, deprecated, renamed: "appLabel")
     static var appLabel: Color {
         .init(
@@ -79,8 +87,6 @@ extension ShapeStyle where Self == Color {
         )
     }
 
-    /// 안눌린 버튼 등
-    /// - Note: 주석 미완성
     @available(*, deprecated, renamed: "secondary")
     static var appSsecondary: Color {
         .init(

--- a/Retrospective/Core/RetrospectiveNavigationStack/PreferenceKeys/LeadingToolBarPreferenceKey.swift
+++ b/Retrospective/Core/RetrospectiveNavigationStack/PreferenceKeys/LeadingToolBarPreferenceKey.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 
-/// <#Description#>
 struct LeadingToolBarPreferenceKey: PreferenceKey {
     static let defaultValue: ToolBarLayout? = nil
     

--- a/Retrospective/Models/Charts/CategoryChartsData.swift
+++ b/Retrospective/Models/Charts/CategoryChartsData.swift
@@ -7,17 +7,28 @@
 
 import SwiftUI
 
-/// <#Description#>
 struct CategoryChartsData: Identifiable {
+    /// 고유 식별자 (UUID)
     let id = UUID()
-    ///
+
+    /// 카테고리의 이름 (차트에서 표시될 라벨)
     var name: String
-    ///
+
+    /// 카테고리의 항목 개수 (총 개수)
     var count: Int
-    ///
+
+    /// 카테고리의 비율 (0.0 ~ 1.0)
+    /// - 총 개수 대비 이 카테고리의 비율을 나타냅니다.
     var rate: Double
-    ///
+
+    /// 카테고리의 색상 (차트에서 사용될 색상)
     var color: Color
+
+    /// 카테고리의 비율을 백분율 문자열로 반환합니다.
+    /// - 예: "25.0%" 또는 "12.5%"
+    var ratePercentage: String {
+        String(format: "%.1f%%", rate * 100)
+    }
 }
 
 extension CategoryChartsData: Hashable { }
@@ -25,11 +36,11 @@ extension CategoryChartsData: Hashable { }
 extension CategoryChartsData {
 
     static let mock: [CategoryChartsData] = [
-        .init(name: "A", count: 10, rate: 0.1, color: .blue),
-        .init(name: "B", count: 20, rate: 0.2, color: .red),
-        .init(name: "C", count: 30, rate: 0.3, color: .yellow),
-        .init(name: "D", count: 40, rate: 0.4, color: .green),
-        .init(name: "E", count: 50, rate: 0.5, color: .purple),
+        .init(name: "A", count: 10, rate: 0.05, color: .blue),
+        .init(name: "B", count: 20, rate: 0.1, color: .red),
+        .init(name: "C", count: 30, rate: 0.2, color: .yellow),
+        .init(name: "D", count: 40, rate: 0.25, color: .green),
+        .init(name: "E", count: 50, rate: 0.4, color: .purple),
     ]
 }
 
@@ -37,9 +48,11 @@ extension CategoryChartsData {
 
 extension Array where Element == CategoryChartsData {
 
+    /// 지정된 인덱스까지의 카테고리 비율(rate)을 누적하여 반환합니다.
+    /// - Parameter index: 누적할 카테고리의 마지막 인덱스입니다.
+    /// - Returns: 지정된 인덱스까지의 누적 비율 값 (Double)
     func accumulatedRate(upTo index: Int) -> Double {
-        var totalRate = 0.0
-        for i in 0..<index { totalRate += self[i].rate }
-        return totalRate
+        guard (0..<count) ~= index else { return 0.0 }
+        return self.prefix(index).reduce(0.0) { $0 + $1.rate }
     }
 }

--- a/Retrospective/Utils/Extesnions/Text+Extension.swift
+++ b/Retrospective/Utils/Extesnions/Text+Extension.swift
@@ -9,11 +9,11 @@ import SwiftUI
 
 extension Text {
 
-    /// <#Description#>
+    /// 지정된 형식(format)과 인수를 사용하여 Text 인스턴스를 생성합니다.
     /// - Parameters:
-    ///   - format: <#format description#>
-    ///   - vrage: <#vrage description#>
-    init(format: String, _ vrage: any CVarArg...) {
-        self.init(String(format: format, arguments: vrage))
+    ///   - format: 포맷 문자열입니다. (예: "Hello, %@!")
+    ///   - arguments: 포맷 문자열에 전달할 인수 목록입니다. (CVarArg)
+    init(format: String, _ arguments: any CVarArg...) {
+        self.init(String(format: format, arguments: arguments))
     }
 }

--- a/Retrospective/Utils/Extesnions/Text+Extension.swift
+++ b/Retrospective/Utils/Extesnions/Text+Extension.swift
@@ -1,0 +1,19 @@
+//
+//  Text+Extension.swift
+//  Retrospective
+//
+//  Created by 김건우 on 5/14/25.
+//
+
+import SwiftUI
+
+extension Text {
+
+    /// <#Description#>
+    /// - Parameters:
+    ///   - format: <#format description#>
+    ///   - vrage: <#vrage description#>
+    init(format: String, _ vrage: any CVarArg...) {
+        self.init(String(format: format, arguments: vrage))
+    }
+}

--- a/Retrospective/Views/ContentView.swift
+++ b/Retrospective/Views/ContentView.swift
@@ -16,32 +16,28 @@ struct ContentView: View {
 
     @State private var selected: Tab = .home
 
+    init() {
+        UITabBar.appearance().isHidden = true
+    }
+
     ///탭바 커스텀을 위해 탭바의 고정된 자리 삭제
     var body: some View {
         ZStack(alignment: .bottom) {
             TabView(selection: $selected) {
-                Group {
-                    NavigationStack {
-                        CategoryManagementView() //TODO: HomeView() 넣어주세요
-                    }
+                CategoryManagementView() //TODO: HomeView() 넣어주세요
                     .tag(Tab.home)
 
-                    NavigationStack {
-                        Test2_View()// searchView() 넣어주세요
-                    }
+                Test2_View()// searchView() 넣어주세요
                     .tag(Tab.search)
 
-                    NavigationStack {
-                        Test3_View()// statistiView() 넣어주세요
-                    }
+                StatisticsView()
                     .tag(Tab.statistic)
-
-                    StatisticsView()
-                        .tag(Tab.setting)
-                }
-                .toolbar(.hidden, for: .tabBar)
+                
+                StatisticsView()
+                    .tag(Tab.setting)
 
             }
+
             tabBar
                 .padding(.bottom, -10)
         }
@@ -77,7 +73,7 @@ struct ContentView: View {
                         .resizable()
                         .scaledToFit()
                         .frame(width: 30)
-                        .foregroundStyle(.black)
+                        .foregroundStyle(.label)
                 }
             }
             Spacer()
@@ -91,7 +87,7 @@ struct ContentView: View {
                         .resizable()
                         .scaledToFit()
                         .frame(width: 30)
-                        .foregroundStyle(.black)
+                        .foregroundStyle(.label)
                 }
             }
             Spacer()
@@ -105,7 +101,7 @@ struct ContentView: View {
                         .resizable()
                         .scaledToFit()
                         .frame(width: 30)
-                        .foregroundStyle(.black)
+                        .foregroundStyle(.label)
                 }
 
             }
@@ -114,7 +110,7 @@ struct ContentView: View {
         }
 
         .frame(width: 350 , height: 80)
-        .background(Color.white)
+        .background(.background)
         .clipShape(RoundedRectangle(cornerRadius: 30))
         .shadow(color: .black.opacity(0.33), radius: 15, x: 5, y: 5)
 
@@ -147,61 +143,6 @@ struct ContentView: View {
         }
     }
 }
-
-
-//        VStack {
-//            Button("FloatingSheet") {
-//                isPresented.toggle()
-//                
-//                
-//            }
-//        }
-//        .padding()
-//        .floatingSheet(isPresented: $isPresented, onDismiss: { print("dismissed") }) {
-//            VStack(alignment: .leading, spacing: 8) {
-//                Text("Marget Caplitalization")
-//                    .font(.title2)
-//                    .fontWeight(.bold)
-//
-//                Text("As of February 3rd, US Time")
-//                    .font(.footnote)
-//                    .foregroundStyle(.secondary)
-//
-//                VStack {
-//                    Text("Stock Price * Shares Outstanding")
-//                        .font(.headline)
-//                        .foregroundStyle(.secondary)
-//                }
-//                .frame(maxWidth: .infinity, alignment: .center)
-//                .padding(.horizontal)
-//                .padding(.vertical, 16)
-//                .cornerRadius(Color(UIColor.systemGray6), radius: 16)
-//                .padding(.top, 24)
-//
-//                Text("Market capitalization represents the total value of a company's stock. It helps compare the size of companies in the stock market")
-//                    .font(.footnote)
-//                    .fontWeight(.semibold)
-//                    .padding(.top, 24)
-//
-//                Button { }
-//                label: {
-//                    Text("Confirm")
-//                        .fontWeight(.bold)
-//                        .foregroundStyle(.white)
-//                }
-//                .frame(maxWidth: .infinity)
-//                .padding(.vertical, 14)
-//                .cornerRadius(.blue, radius: 14)
-//                .padding(.top, 12)
-//
-//            }
-//            .frame(maxWidth: .infinity, alignment: .leading)
-//            .padding(.vertical, 4)
-//            .padding(.horizontal, 4)
-//
-//        }
-
-
 
 #Preview {
     ContentView()

--- a/Retrospective/Views/ContentView.swift
+++ b/Retrospective/Views/ContentView.swift
@@ -24,19 +24,22 @@ struct ContentView: View {
     var body: some View {
         ZStack(alignment: .bottom) {
             TabView(selection: $selected) {
-                CategoryManagementView() //TODO: HomeView() 넣어주세요
-                    .tag(Tab.home)
+                Group {
+                    CategoryManagementView() //TODO: HomeView() 넣어주세요
+                        .tag(Tab.home)
 
-                Test2_View()// searchView() 넣어주세요
-                    .tag(Tab.search)
+                    Test2_View()// searchView() 넣어주세요
+                        .tag(Tab.search)
 
-                StatisticsView()
-                    .tag(Tab.statistic)
-                
-                StatisticsView()
-                    .tag(Tab.setting)
+                    StatisticsView()
+                        .tag(Tab.statistic)
 
+                    StatisticsView()
+                        .tag(Tab.setting)
+                }
+                .toolbar(.hidden, for: .tabBar)
             }
+            
 
             tabBar
                 .padding(.bottom, -10)

--- a/Retrospective/Views/StatisticsView/Components/CircleButton.swift
+++ b/Retrospective/Views/StatisticsView/Components/CircleButton.swift
@@ -31,7 +31,7 @@ struct CircleButton: View {
                 .font(.title)
                 .foregroundStyle(.background)
                 .padding()
-                .background(.appLightPeach, in: .circle)
+                .background(.appSkyBlue2, in: .circle)
 
         }
 

--- a/Retrospective/Views/StatisticsView/Components/CircleButton.swift
+++ b/Retrospective/Views/StatisticsView/Components/CircleButton.swift
@@ -29,7 +29,7 @@ struct CircleButton: View {
         } label: {
             Image(systemName: systemName)
                 .font(.title)
-                .foregroundStyle(.background)
+                .foregroundStyle(.label)
                 .padding()
                 .background(.appSkyBlue2, in: .circle)
 

--- a/Retrospective/Views/StatisticsView/Components/CircleButton.swift
+++ b/Retrospective/Views/StatisticsView/Components/CircleButton.swift
@@ -9,15 +9,15 @@ import SwiftUI
 
 struct CircleButton: View {
 
-    ///
+    /// 시스템 아이콘 이름 (SF Symbols)
     private let systemName: String
-    ///
+    /// 버튼 클릭 시 실행될 동작 (클로저)
     private let action: () -> Void
 
-    /// <#Description#>
+    /// CircleButton 초기화 메서드
     /// - Parameters:
-    ///   - systemName: <#systemName description#>
-    ///   - action: <#action description#>
+    ///   - systemName: SF Symbols 아이콘 이름입니다. (예: "house", "heart.fill")
+    ///   - action: 버튼 클릭 시 실행될 동작을 지정하는 클로저입니다.
     init(systemName: String, action: @escaping () -> Void) {
         self.action = action
         self.systemName = systemName

--- a/Retrospective/Views/StatisticsView/DateRangeSelectionView.swift
+++ b/Retrospective/Views/StatisticsView/DateRangeSelectionView.swift
@@ -74,7 +74,7 @@ struct DateRangeSelectionView: View {
                             Text(dateSelection?.nextWeek?.formatted(.yyyyMMdd) ?? "Nil")
                                 .offset(x: 15)
                         }
-                        .font(.title3)
+                        .font(.headline)
                     case .month:
                         Text(dateSelection?.formatted(.yyyyMM) ?? "Nil")
                             .font(.largeTitle)

--- a/Retrospective/Views/StatisticsView/DateRangeSelectionView.swift
+++ b/Retrospective/Views/StatisticsView/DateRangeSelectionView.swift
@@ -95,7 +95,7 @@ struct DateRangeSelectionView: View {
                 Text("확인")
                     .font(.title2)
                     .fontWeight(.semibold)
-                    .foregroundStyle(.background)
+                    .foregroundStyle(.label)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 14)
                     .background(.appSkyBlue2)

--- a/Retrospective/Views/StatisticsView/DateRangeSelectionView.swift
+++ b/Retrospective/Views/StatisticsView/DateRangeSelectionView.swift
@@ -98,6 +98,7 @@ struct DateRangeSelectionView: View {
                     .foregroundStyle(.background)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 14)
+                    .background(.appSkyBlue2)
                     .cornerRadius(.appLightPeach, radius: 18)
             }
             .padding(.top, 60)

--- a/Retrospective/Views/StatisticsView/DonutChartsView.swift
+++ b/Retrospective/Views/StatisticsView/DonutChartsView.swift
@@ -35,8 +35,8 @@ struct DonutChartsView: View {
                             .stroke(data.color, lineWidth: 3.5)
                             .frame(width: 10, height: 10)
                         HStack(alignment: .firstTextBaseline) {
-                            Text("\(data.name)")
-                            Text(String(format: "(%.1f%%)", data.rate * 100))
+                            Text(data.name)
+                            Text(data.ratePercentage)
                                 .font(.caption)
                                 .fontWeight(.light)
                         }

--- a/Retrospective/Views/StatisticsView/StatisticsView.swift
+++ b/Retrospective/Views/StatisticsView/StatisticsView.swift
@@ -101,8 +101,8 @@ extension StatisticsView {
                     Text("\(data.name)")
                         .fontWeight(.bold)
                     Spacer()
-                    Text("\(data.count)")
-                    Text(String(format: "(%.1f%%)", data.rate * 100))
+                    Text("\(data.count)개")
+                    Text(format: "(%.1f%%)", data.rate * 100)
                         .font(.caption)
                         .fontWeight(.light)
                 }

--- a/Retrospective/Views/StatisticsView/StatisticsView.swift
+++ b/Retrospective/Views/StatisticsView/StatisticsView.swift
@@ -41,15 +41,15 @@ struct StatisticsView: View {
                     .padding(.top, 20)
                     .padding(.horizontal)
             }
-            .floatingSheet(isPresented: $isPresentDateRangePicker) {
-                DateRangeSelectionView(
-                    isPresented: $isPresentDateRangePicker,
-                    periodSelection: $periodSelection,
-                    dateRange: $dateRange
-                )
-            }
             .retrospectiveNavigationTitle("통계")
             .retrospectiveNavigationBarColor(.appLightPeach)
+        }
+        .floatingSheet(isPresented: $isPresentDateRangePicker) {
+            DateRangeSelectionView(
+                isPresented: $isPresentDateRangePicker,
+                periodSelection: $periodSelection,
+                dateRange: $dateRange
+            )
         }
     }
 }
@@ -86,6 +86,8 @@ extension StatisticsView {
             }
         }
         .background(.appLightPeach)
+        .contentMargins(.bottom, 80, for: .scrollContent)
+        .scrollIndicators(.hidden)
     }
 
     var categoryDetailCardView: some View {

--- a/Retrospective/Views/StatisticsView/StatisticsView.swift
+++ b/Retrospective/Views/StatisticsView/StatisticsView.swift
@@ -102,7 +102,7 @@ extension StatisticsView {
                         .fontWeight(.bold)
                     Spacer()
                     Text("\(data.count)개")
-                    Text(format: "(%.1f%%)", data.rate * 100)
+                    Text(data.ratePercentage)
                         .font(.caption)
                         .fontWeight(.light)
                 }


### PR DESCRIPTION
## #️⃣ Related Issues

> ex) #IssueNumber, #IssueNumber

## 📝 Task Details

> Please briefly describe what was worked on in this PR (Images can be attached).


<img width="729" alt="스크린샷 2025-05-14 오전 1 57 13" src="https://github.com/user-attachments/assets/6054ce69-a6c0-4509-a36c-9515edcd2ad2" />

* GPT 선생님께 부탁해서 다크 모드 색상도 추가했습니다~

<img width="734" alt="스크린샷 2025-05-14 오전 2 05 14" src="https://github.com/user-attachments/assets/3e1603c4-623c-4b6f-a3e3-030618ba67d5" />


<img width="756" alt="스크린샷 2025-05-14 오전 2 04 47" src="https://github.com/user-attachments/assets/94b7f3e7-374e-411c-8ce4-650e6e5e3f22" />

* 대충 요런 느낌입니다. 



#### 기타

- [x] `FloatingSheet`가 탭뷰 뒤로 가려지는 문제 수정 ⭐️
- [x] 'FloatingSheet'의 뒷 배경이 네비게이션 바까지 채워지지 않는 문제 수정 ⭐️
- [x] 통계 화면의 자세히 보기에서 카테고리 개수 '개' 문자열 추가
- [x] 주석 작성 안한 코드(EmptyStateView, CategoryChartsData 등) 문서화 주석 작성
- [x] 통계 화면 및 하위 화면 다크 모드 완벽하게 대응
- [x]  Text+Extnesion - Text(format: args:) 확장 메서드 구현


### Screenshot (Optional)

## 💬 Review Requests (Optional)

> If there are specific areas you want the reviewer to focus on, please mention them.
