### PR TITLE
HomeView에서 Components로 Month Header, DayHeader, CardScrollView 이동. / …

### DIFF
--- a/Retrospective/Views/HomeView/Components/CardScrollView.swift
+++ b/Retrospective/Views/HomeView/Components/CardScrollView.swift
@@ -1,0 +1,46 @@
+//
+//  CardScrollView.swift
+//  Retrospective
+//
+//  Created by 신유섭 on 5/14/25.
+//
+
+import SwiftUI
+
+struct CardScrollView: View {
+    @Binding var isDescending: Bool
+
+    let groupedByMonthAndDay: [String: [String: [Diary]]]
+
+
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
+                ForEach(groupedByMonthAndDay.keys.sorted(by: { isDescending ? $0 > $1 : $0 < $1 }), id: \.self) { monthKey in
+                    if let days = groupedByMonthAndDay[monthKey] {
+                        
+                        Section(header: MonthHeader(title: monthKey)) {
+                            ForEach(days.keys.sorted(by: { isDescending ? $0 > $1 : $0 < $1 }), id: \.self) { dayKey in
+                                if let diaries = days[dayKey] {
+                                    Section(header: DayHeader(title: dayKey)) {
+                                        ForEach(diaries) { diary in
+                                            VStack(alignment: .leading) {
+                                                CardUIView(diary: diary)
+                                            }
+                                            
+                                            
+                                            .padding(.vertical, 4)
+                                            .frame(maxWidth: .infinity, alignment: .leading)
+                                            .background(Color.gray.opacity(0.05))
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Retrospective/Views/HomeView/Components/DayHeader.swift
+++ b/Retrospective/Views/HomeView/Components/DayHeader.swift
@@ -1,0 +1,22 @@
+//
+//  DayHeader.swift
+//  Retrospective
+//
+//  Created by 신유섭 on 5/14/25.
+//
+import SwiftUI
+
+struct DayHeader: View {
+    let title: String
+    var body: some View {
+        HStack {
+            Text(title)
+                .foregroundStyle(Color.secondary)
+                .font(.title3)
+
+
+            Spacer()
+        }
+        .padding(.top, 10)
+    }
+}

--- a/Retrospective/Views/HomeView/Components/MonthHeader.swift
+++ b/Retrospective/Views/HomeView/Components/MonthHeader.swift
@@ -1,0 +1,26 @@
+//
+//  MonthHeader.swift
+//  Retrospective
+//
+//  Created by 신유섭 on 5/14/25.
+//
+import SwiftUI
+
+struct MonthHeader: View {
+    let title: String
+    var body: some View {
+        HStack {
+
+            Text(title)
+                .foregroundStyle(Color.secondary)
+                .font(.title)
+
+
+            Spacer()
+
+        }
+        .frame(maxWidth: .infinity)
+        .background(Color.appLightPeach)
+        .padding(.bottom, 10)
+    }
+}

--- a/Retrospective/Views/HomeView/HomeView.swift
+++ b/Retrospective/Views/HomeView/HomeView.swift
@@ -23,7 +23,6 @@ struct HomeView: View {
         }
     }
 
-
     var filteredDiaries: [Diary] {
         guard !filteringCategories.isEmpty else { return allDiaries }
 
@@ -75,34 +74,7 @@ struct HomeView: View {
                 }
                 .padding(.horizontal, 20)
 
-                ScrollView {
-                    LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
-                        ForEach(groupedByMonthAndDay.keys.sorted(by: { isDescending ? $0 > $1 : $0 < $1 }), id: \.self) { monthKey in
-                            if let days = groupedByMonthAndDay[monthKey] {
-
-                                Section(header: MonthHeader(title: monthKey)) {
-                                    ForEach(days.keys.sorted(by: { isDescending ? $0 > $1 : $0 < $1 }), id: \.self) { dayKey in
-                                        if let diaries = days[dayKey] {
-                                            Section(header: DayHeader(title: dayKey)) {
-                                                ForEach(diaries) { diary in
-                                                    VStack(alignment: .leading) {
-                                                        CardUIView(diary: diary)
-                                                    }
-
-
-                                                    .padding(.vertical, 4)
-                                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                                    .background(Color.gray.opacity(0.05))
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-
+                CardScrollView(isDescending: $isDescending, groupedByMonthAndDay: groupedByMonthAndDay)
             }
             .background(Color.appLightPeach)
             .padding(.horizontal)
@@ -119,38 +91,6 @@ struct HomeView: View {
                     FilterSelectView(filteringCategories: $filteringCategories)
                 }
             }
-        }
-    }
-}
-
-struct MonthHeader: View {
-    let title: String
-    var body: some View {
-        HStack {
-
-            Text(title)
-                .foregroundStyle(Color.secondary)
-                .font(.title)
-
-
-            Spacer()
-
-        }
-        .frame(maxWidth: .infinity)
-        .background(Color.appLightPeach)
-    }
-}
-
-struct DayHeader: View {
-    let title: String
-    var body: some View {
-        HStack {
-            Text(title)
-                .foregroundStyle(Color.secondary)
-                .font(.title3)
-
-
-            Spacer()
         }
     }
 }

--- a/Retrospective/Views/SearchView/SearchView.swift
+++ b/Retrospective/Views/SearchView/SearchView.swift
@@ -1,0 +1,184 @@
+//
+//  HomeView.swift
+//  Retrospective
+//
+//  Created by 신유섭 on 5/14/25.
+//
+
+
+//
+//  HomeView.swift
+//  Retrospective
+//
+//  Created by 신유섭 on 5/12/25.
+//
+
+import SwiftData
+import SwiftUI
+
+struct SearchView: View {
+
+    @State var filterSelectViewPresented: Bool = false
+    @State var isDescending: Bool = true
+    @State var filteringCategories: Set<String> = []
+    @State var searchText: String = ""
+
+    @State var searchingInTitle: Bool = true
+    @State var searchingInContents: Bool = false
+
+    @Query var allDiaries: [Diary]
+    @Query var allCategories: [Category]
+
+    var filteredCategories: [Category] {
+        return allCategories.filter { category in
+            filteringCategories.contains(category.name)
+        }
+    }
+
+    var filteredDiaries: [Diary] {
+        guard !filteringCategories.isEmpty else { return allDiaries }
+
+        return allDiaries.filter { diary in
+            // 하나라도 겹치면 통과
+            let categoryNames = diary.categories.map { $0.name }
+            return !filteringCategories.isDisjoint(with: categoryNames)
+        }
+    }
+
+    var searchedDiaries: [Diary] {
+        return filteredDiaries.filter { diary in
+            let isSearchedInTitle = diary.title.localizedCaseInsensitiveContains(searchText)
+            let isSearchedInContents = diary.contents.localizedCaseInsensitiveContains(searchText)
+
+            switch (searchingInTitle, searchingInContents) {
+            case (true, true):
+                return isSearchedInTitle || isSearchedInContents
+            case (true, false):
+                return isSearchedInTitle
+            case (false, true):
+                return isSearchedInContents
+            case (false, false):
+                return false
+            }
+        }
+    }
+
+    var groupedByMonthAndDay: [String: [String: [Diary]]] {
+        searchedDiaries.groupByMonthAndDay()
+    }
+
+    var currentSearchScopeText: String {
+        switch (searchingInTitle, searchingInContents) {
+        case (true, true): return "제목 + 내용"
+        case (true, false): return "제목만"
+        case (false, true): return "내용만"
+        default: return "검색 안 함"
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack {
+
+                HStack {
+                    ScrollView(.horizontal) {
+                        HStack {
+                            ForEach (filteredCategories, id: \.self ) {category in
+                                CategoryButton(isCategoryOn: .constant(true), category: category.name, categoryColor: category.color)
+
+
+                            }
+                        }
+                        .padding(.vertical, 5)
+
+                    }
+
+                    Button {
+                        isDescending.toggle()
+                    } label: {
+                        if isDescending {
+                            HStack(spacing: 0) {
+                                Text("최신순")
+                                Image(systemName: "arrowtriangle.down")
+                            }
+                        } else {
+                            HStack(spacing: 0) {
+                                Text("오래된순")
+                                Image(systemName: "arrowtriangle.up")
+                            }
+                        }
+
+                    }
+                }
+
+                HStack {
+                    Image(systemName: "magnifyingglass")
+                        .foregroundStyle(Color.secondary)
+                        .bold()
+
+                    TextField("Search", text: $searchText, prompt: Text("Search")
+                        .foregroundStyle(Color.secondary))
+
+                    Menu {
+                        Button("제목만") {
+                            searchingInTitle = true
+                            searchingInContents = false
+                        }
+
+                        Button("내용만") {
+                            searchingInTitle = false
+                            searchingInContents = true
+                        }
+
+                        Button("제목 + 내용") {
+                            searchingInTitle = true
+                            searchingInContents = true
+                        }
+                    } label: {
+                        Label(currentSearchScopeText, systemImage: "line.3.horizontal.decrease.circle")
+                            .padding()
+                            .background(Color.gray.opacity(0.1))
+                            .cornerRadius(8)
+                    }
+                }
+
+                if searchText.isEmpty {
+                    VStack {
+                        Image(systemName: "magnifyingglass")
+                            .font(.largeTitle)
+                            .bold()
+                        Text("검색어를 입력해주세요!")
+                            .font(.largeTitle)
+                            .bold()
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .foregroundStyle(Color.secondary)
+
+                } else {
+                    CardScrollView(isDescending: $isDescending, groupedByMonthAndDay: groupedByMonthAndDay)
+                }
+
+            }
+            .background(Color.appLightPeach)
+            .padding(.horizontal)
+            .toolbar {
+
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Two") {
+                        filterSelectViewPresented = true
+                    }
+                }
+            }
+            .sheet(isPresented: $filterSelectViewPresented) {
+                NavigationStack {
+                    FilterSelectView(filteringCategories: $filteringCategories)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    SearchView()
+        .modelContainer(PersistenceManager.previewContainer)
+}


### PR DESCRIPTION
1. SearchView 추가 구현

SearchView 초안 추가하였습니다.

Filtering 및 Search 기능
- Filtering은 HomeView와 동일합니다.
- Search는 제목만, 내용만, 제목+내용 3가지 방식으로 검색할 수 있습니다.
- Filtering과 Search는 동시에 구현됩니다.

추후 진행 예정 사항
1 - a. HomeView와 SearchView 모두 네비게이션 바 수정 예정입니다.
-> RetrospectiveNavigationStack 공부하고 추가하겠습니다. 
1 - b. FilterSelectView Floating View로 수정.

2. HomeView에서 MonthHeader, DayHeader, CardScrollView
-> Components 폴더로 따로 분리하였습니다.

### Screenshot (Optional)
<img width="339" alt="스크린샷 2025-05-14 오전 2 37 59" src="https://github.com/user-attachments/assets/78b793d1-17de-4d23-b543-32dd2277f2fa" />

## 💬 Review Requests (Optional)

현재는 HomeView와 SearchView가 필터, 정렬 상태를 공유하지 않습니다.
공유하는게 나을지 의견 부탁드립니다!
