### PR TITLE
feat: 도넛 차트에서 표시되는 데이터의 개수를 5개로 제한

### DIFF
--- a/Retrospective/Core/RetrospectiveNavigationStack/RetrospectiveNavigationStack.swift
+++ b/Retrospective/Core/RetrospectiveNavigationStack/RetrospectiveNavigationStack.swift
@@ -40,18 +40,18 @@ struct RetrospectiveNavigationStack<Root>: View where Root: View {
             }
             .toolbarVisibility(.hidden, for: .navigationBar)
             .navigationBarBackButtonHidden()
-        }
-        .onPreferenceChangeMainActor(NavigationTitlePreferenceKey.self) { title in
-            navigationTitle = title
-        }
-        .onPreferenceChangeMainActor(LeadingToolBarPreferenceKey.self) { toolbar in
-            leadingToolbar = toolbar
-        }
-        .onPreferenceChangeMainActor(TrailingToolBarPreferenceKey.self) { toolbar in
-            trailingToolbar = toolbar
-        }
-        .onPreferenceChangeMainActor(NavigationBarColorPreferenceKey.self) { color in
-            navigationBarColor = color
+            .onPreferenceChangeMainActor(NavigationTitlePreferenceKey.self) { title in
+                navigationTitle = title
+            }
+            .onPreferenceChangeMainActor(LeadingToolBarPreferenceKey.self) { toolbar in
+                leadingToolbar = toolbar
+            }
+            .onPreferenceChangeMainActor(TrailingToolBarPreferenceKey.self) { toolbar in
+                trailingToolbar = toolbar
+            }
+            .onPreferenceChangeMainActor(NavigationBarColorPreferenceKey.self) { color in
+                navigationBarColor = color
+            }
         }
     }
 }

--- a/Retrospective/Models/Charts/CategoryChartsData.swift
+++ b/Retrospective/Models/Charts/CategoryChartsData.swift
@@ -38,9 +38,13 @@ extension CategoryChartsData {
     static let mock: [CategoryChartsData] = [
         .init(name: "A", count: 10, rate: 0.05, color: .blue),
         .init(name: "B", count: 20, rate: 0.1, color: .red),
-        .init(name: "C", count: 30, rate: 0.2, color: .yellow),
-        .init(name: "D", count: 40, rate: 0.25, color: .green),
-        .init(name: "E", count: 50, rate: 0.4, color: .purple),
+        .init(name: "C", count: 30, rate: 0.1, color: .yellow),
+        .init(name: "D", count: 40, rate: 0.1, color: .green),
+        .init(name: "E", count: 50, rate: 0.1, color: .purple),
+        .init(name: "F", count: 60, rate: 0.1, color: .orange),
+        .init(name: "G", count: 70, rate: 0.1, color: .pink),
+        .init(name: "H", count: 80, rate: 0.15, color: .brown),
+        .init(name: "I", count: 90, rate: 0.2, color: .black),
     ]
 }
 

--- a/Retrospective/Utils/Extesnions/Array+Extension.swift
+++ b/Retrospective/Utils/Extesnions/Array+Extension.swift
@@ -27,3 +27,14 @@ extension Array where Element == Diary {
         return symbols[(weekday - 1 + 7) % 7]
     }
 }
+
+
+extension Array {
+    
+    /// <#Description#>
+    /// - Parameter convertToArrayImmediately: <#convertToArrayImmediately description#>
+    /// - Returns: <#description#>
+    func prefix(length convertToArrayImmediately: Int) -> Array<Element> {
+        Array(self.prefix(convertToArrayImmediately))
+    }
+}

--- a/Retrospective/Views/SettingView/SettingView.swift
+++ b/Retrospective/Views/SettingView/SettingView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct settingView: View {
+struct SettingView: View {
     @Environment(\.dismiss) var dismiss: DismissAction
 
     var body: some View {
@@ -32,7 +32,7 @@ struct settingView: View {
                     VStack {
                         NavigationLink(destination: CategoryView()) {
                             HStack {
-                                Text("카테고리설정")
+                                Text("카테고리")
                                     .font(.headline)
 
                                 Spacer()
@@ -64,6 +64,6 @@ struct settingView: View {
 
 
 #Preview {
-    settingView()
+    SettingView()
         .modelContainer(PersistenceManager.previewContainer)
 }

--- a/Retrospective/Views/StatisticsView/Components/CategoryChartsListView.swift
+++ b/Retrospective/Views/StatisticsView/Components/CategoryChartsListView.swift
@@ -1,0 +1,57 @@
+//
+//  CategoryChartsListView.swift
+//  Retrospective
+//
+//  Created by 김건우 on 5/14/25.
+//
+
+import SwiftUI
+
+struct CategoryChartsListView: View {
+
+    let datas: [CategoryChartsData]
+
+    var body: some View {
+        VStack {
+            Text("세부 정보")
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+
+            ForEach(datas) { data in
+                categoryStatisticsRow(data: data)
+            }
+        }
+        .padding(.horizontal)
+    }
+}
+
+extension CategoryChartsListView {
+    
+    func categoryStatisticsRow(data: CategoryChartsData) -> some View {
+        HStack {
+            HStack(alignment: .firstTextBaseline) {
+                Circle()
+                    .stroke(data.color, lineWidth: 3.5)
+                    .frame(width: 10, height: 10)
+
+                Text("\(data.name)")
+                    .fontWeight(.bold)
+                Spacer()
+                Text("\(data.count)개")
+                Text("(\(data.ratePercentage))")
+                    .font(.caption)
+                    .fontWeight(.light)
+            }
+
+        }
+        .padding(8)
+        .padding(.horizontal, 14)
+        .cornerRadius(.background, radius: 8)
+        .defaultShadow(.black.opacity(0.11))
+    }
+}
+
+#Preview {
+    CategoryChartsListView(datas: CategoryChartsData.mock)
+}

--- a/Retrospective/Views/StatisticsView/DonutChartsView.swift
+++ b/Retrospective/Views/StatisticsView/DonutChartsView.swift
@@ -60,7 +60,7 @@ extension DonutChartsView {
     var legendChipView: some View {
         ChipLayout(horizontalSpacing: 18) {
             Spacer()
-            ForEach(datas) { data in
+            ForEach(datas.prefix(length: 5)) { data in
                 HStack {
                     Circle()
                         .stroke(data.color, lineWidth: 3.5)

--- a/Retrospective/Views/StatisticsView/StatisticsListView.swift
+++ b/Retrospective/Views/StatisticsView/StatisticsListView.swift
@@ -1,0 +1,36 @@
+//
+//  StatisticsListView.swift
+//  Retrospective
+//
+//  Created by 김건우 on 5/14/25.
+//
+
+import SwiftUI
+
+struct StatisticsListView: View {
+
+    @Environment(\.dismiss) var dismiss: DismissAction
+
+    let datas: [CategoryChartsData]
+
+    var body: some View {
+        RetrospectiveNavigationStack {
+            ScrollView {
+                CategoryChartsListView(datas: datas)
+            }
+            .contentMargins(.vertical, 18)
+            .background(.appLightPeach)
+            .retrospectiveLeadingToolBar {
+                RetrospectiveToolBarItem(.symbol("chevron.left")) {
+                    dismiss()
+                }
+            }
+            .retrospectiveNavigationTitle("통계 세부 정보")
+            .retrospectiveNavigationBarColor(.appLightPeach)
+        }
+    }
+}
+
+#Preview {
+    StatisticsListView(datas: CategoryChartsData.mock)
+}

--- a/Retrospective/Views/StatisticsView/StatisticsView.swift
+++ b/Retrospective/Views/StatisticsView/StatisticsView.swift
@@ -75,15 +75,10 @@ extension StatisticsView {
 
                 Divider()
 
-                VStack {
-                    Text("세부 정보")
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
+                CategoryChartsListView(datas: chartsDatas.prefix(length: 5))
+                    .padding(.top)
 
-                    categoryDetailCardView
-                }
-                .padding()
+                moreLinkButton
             }
         }
         .background(.appLightPeach)
@@ -92,27 +87,57 @@ extension StatisticsView {
     }
 
     var categoryDetailCardView: some View {
-        ForEach(chartsDatas) { data in
+        VStack {
+            Text("세부 정보")
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+
+            ForEach(chartsDatas.prefix(5)) { data in
+                HStack {
+                    HStack(alignment: .firstTextBaseline) {
+                        Circle()
+                            .stroke(data.color, lineWidth: 3.5)
+                            .frame(width: 10, height: 10)
+
+                        Text("\(data.name)")
+                            .fontWeight(.bold)
+                        Spacer()
+                        Text("\(data.count)개")
+                        Text("(\(data.ratePercentage))")
+                            .font(.caption)
+                            .fontWeight(.light)
+                    }
+
+                }
+                .padding(8)
+                .padding(.horizontal, 14)
+                .cornerRadius(.background, radius: 8)
+                .defaultShadow(.black.opacity(0.11))
+            }
+        }
+        .padding()
+    }
+
+    var moreLinkButton: some View {
+        NavigationLink {
+            StatisticsListView(datas: chartsDatas)
+        } label: {
             HStack {
                 HStack(alignment: .firstTextBaseline) {
-                    Circle()
-                        .stroke(data.color, lineWidth: 3.5)
-                        .frame(width: 10, height: 10)
-
-                    Text("\(data.name)")
+                    Text("더보기")
                         .fontWeight(.bold)
                     Spacer()
-                    Text("\(data.count)개")
-                    Text("(\(data.ratePercentage))")
-                        .font(.caption)
+                    Image(systemName: "chevron.right")
                         .fontWeight(.light)
                 }
-
+                .foregroundStyle(.label)
             }
             .padding(8)
             .padding(.horizontal, 14)
             .cornerRadius(.background, radius: 8)
             .defaultShadow(.black.opacity(0.11))
+            .padding(.horizontal)
         }
     }
 


### PR DESCRIPTION
## #️⃣ Related Issues

close #47 

## 📝 Task Details

#### 도넛 차트에서 표시되는 데이터의 개수를 5개로 제한

* 말씀해주신 바와 같이, 도넛 차트에서 범례(Legend)와 아래 리스트를 5개로 제한하고, '더보기' 버튼을 만들었습니다.
    * '더보기' 버튼을 클릭하면 두 번째 화면으로 이동합니다.

#### RetrospectiveNavigationStack 버그 수정

* 다른 화면으로 이동(push)할 때, 앞서 화면과 새로운 화면의 네비게이션 제목이 동시에 바뀔 수 있는 문제 수정

### Screenshot

<img width="481" alt="스크린샷 2025-05-14 오후 9 13 14" src="https://github.com/user-attachments/assets/b4d958a1-3f5e-49e3-afd0-54c12353b52b" />

<img width="491" alt="스크린샷 2025-05-14 오후 9 13 08" src="https://github.com/user-attachments/assets/52a2d7c8-ff9a-4f24-9bd0-52a38fef96b0" />