### PR TITLE
카테고리뷰 수정

### DIFF
--- a/Retrospective/Views/CategoryView/CategoryTest_View.swift
+++ b/Retrospective/Views/CategoryView/CategoryTest_View.swift
@@ -35,6 +35,7 @@ struct CategoryTestView: View {
                                 newCategoryName = String(newValue.prefix(15))
                             }
                         }
+                        .padding(.leading,-20)
 
                     Button(action: {
                         addCategory()

--- a/Retrospective/Views/CategoryView/CategoryTest_View.swift
+++ b/Retrospective/Views/CategoryView/CategoryTest_View.swift
@@ -21,13 +21,20 @@ struct CategoryTestView: View {
     @State private var showingDuplicateAlert: Bool = false
     @State private var categoryToDelete: Category? = nil
     @State private var showingDeleteAlert: Bool = false
+    @State private var textLength: String = ""
+    @State private var showingMinimumCategoryAlert = false
 
     var body: some View {
         NavigationStack {
             VStack(spacing: -20) {
-                /// 새 카테고리 입력 필드
+
                 HStack{
                     CustomTextField(placeholder: "카테고리 이름을 작성해주세요.", text: $newCategoryName)
+                        .onChange(of: newCategoryName) { newValue in
+                            if newValue.count > 15 {
+                                newCategoryName = String(newValue.prefix(15))
+                            }
+                        }
 
                     Button(action: {
                         addCategory()
@@ -35,6 +42,7 @@ struct CategoryTestView: View {
                         Image(systemName: "plus")
                             .font(.title3)
                             .font(.headline)
+                            
                     }
 
                     .disabled(newCategoryName.isEmpty)
@@ -42,7 +50,7 @@ struct CategoryTestView: View {
                 }
 
                 .padding(.vertical, 0)
-                .padding(.horizontal, 10)
+                .padding(.horizontal, 25)
                 /// 카테고리 리스트
 
                 ScrollView{
@@ -57,20 +65,24 @@ struct CategoryTestView: View {
                                 Spacer()
 
                                 NavigationLink(destination: EditCategoryView(category: category)) {
-                                    Image(systemName: "square.and.pencil")
+                                    Image(systemName: "pencil")
                                         .font(.title3)
                                         .foregroundStyle(.label)
                                         .padding(.horizontal,20)
                                 }
 
                                 Button {
-                                    categoryToDelete = category
-                                    showingDeleteAlert = true
+                                    if categories.count <= 1 {
+                                        showingMinimumCategoryAlert = true
+                                    } else {
+                                        categoryToDelete = category
+                                        showingDeleteAlert = true
+                                    }
                                 } label: {
                                     Image(systemName: "trash")
                                         .font(.title3)
                                 }
-                                .foregroundStyle(.label)
+                                .foregroundStyle(.red)
 
                             }
                             .frame(maxWidth: .infinity, maxHeight: .infinity ,alignment: .leading)
@@ -83,6 +95,7 @@ struct CategoryTestView: View {
 
                 }
                 .padding()
+                .contentMargins(.bottom,80, for: .scrollContent)
             }
         }
 
@@ -93,16 +106,20 @@ struct CategoryTestView: View {
             Button("확인", role: .cancel) { }
         }
         .alert("이 카테고리를 삭제하시겠습니까?", isPresented: $showingDeleteAlert) {
-                    Button("예", role: .destructive) {
-                        if let category = categoryToDelete {
-                            context.delete(category)
-                            categoryToDelete = nil
-                        }
-                    }
-                    Button("아니오", role: .cancel) {
-                        categoryToDelete = nil
-                    }
+            Button("예", role: .destructive) {
+                if let category = categoryToDelete {
+                    context.delete(category)
+                    categoryToDelete = nil
                 }
+            }
+            Button("아니오", role: .cancel) {
+                categoryToDelete = nil
+            }
+        }
+
+        .alert("최소 한개 이상의 카테고리가 필요합니다.", isPresented: $showingMinimumCategoryAlert) {
+            Button("확인", role: .cancel) { }
+        }
             }
 
 

--- a/Retrospective/Views/CategoryView/CategoryView.swift
+++ b/Retrospective/Views/CategoryView/CategoryView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct CategoryView: View {
-
+    @Environment(\.dismiss) private var dismiss
     @State var isCategoryOn: Bool = false
     var body: some View {
         RetrospectiveNavigationStack{
@@ -19,6 +19,11 @@ struct CategoryView: View {
                 }
                 .retrospectiveNavigationTitle("카테고리 관리")
                 .retrospectiveNavigationBarColor(.appLightPeach)
+                .retrospectiveLeadingToolBar {
+                    RetrospectiveToolBarItem(.symbol("chevron.left")) {
+                        dismiss()
+                    }
+                }
         }
     }
 }


### PR DESCRIPTION
## #️⃣ Related Issues
카테고리 뷰 재수정 완료했습니다.

## 📝 Task Details
- 텍스트필드 글자수 15자 제한
- 수정아이콘 펜슬 모양으로 변경 및 삭제 아이콘 색상 변경
- “+” 버튼 양옆 간격조절
- 카테고리 최소 1개 이상 보여주기
- 네비게이션 바 에서 뒤로가기 클릭시 dissmiss 추가하기
- 스크롤뷰에 contentMargins 적용

### Screenshot 
<img width="439" alt="스크린샷 2025-05-15 오전 1 42 26" src="https://github.com/user-attachments/assets/5c5d77d6-b0e2-4452-81b4-2edcecc551f2" />



## 💬 Review Requests (Optional)
