### PR TITLE
카테고리 수정뷰 수정

### DIFF
--- a/Retrospective/Views/CategoryView/EditCategoryView.swift
+++ b/Retrospective/Views/CategoryView/EditCategoryView.swift
@@ -44,7 +44,7 @@ struct EditCategoryView: View {
                     HStack(alignment: .center){
 
                         TextField("카테고리 이름", text: $editedName)
-                            .font(.system(size: 30, weight: .semibold, design: .default))
+                            .font(.title)
 
                             .multilineTextAlignment(.center)
                             .frame(maxWidth: .infinity, minHeight: 10)
@@ -62,19 +62,20 @@ struct EditCategoryView: View {
                 .background(Color.appLightPeach)
 
 
-                // 미리보기 색상 아이콘
+
                 VStack{
                     Circle()
                         .fill(editedColor)
                         .frame(width: 200, height: 200)
 
 
-                    // 슬라이더 UI
+
                     Group {
                         sliderView(value: $r, label: "Red", color: .red)
                         sliderView(value: $g, label: "Green", color: .green)
                         sliderView(value: $b, label: "Blue", color: .blue)
                     }
+                    .padding()
 
 //                    RoundedRectButton(title: "저장") {
 //                        let rgb = editedColor.rgbComponents()


### PR DESCRIPTION
## #️⃣ Related Issues

카테고리 수정뷰 수정

## 📝 Task Details

-  텍스트 필드 DynamicType 적용
- 슬라이더와 circle사이에 padding추가

### Screenshot (Op
<img width="424" alt="스크린샷 2025-05-14 오후 11 50 32" src="https://github.com/user-attachments/assets/fbb2abe0-0269-4340-b792-d0c34a786c80" />
tional)
<img width="509" alt="스크린샷 2025-05-14 오후 11 51 32" src="https://github.com/user-attachments/assets/bd37c276-1682-4bf4-b3d4-e39c840c6b7
<img width="519" alt="스크린샷 2025-05-14 오후 11 52 02" src="https://github.com/user-attachments/assets/56b0167a-b341-421c-b438-801027972b6c" />
2" />

## 💬 Review Requests (Optional)
1.아이패드 세로뷰에서만 밑에 여백이 좀 많이 보이네요. 많이 부자연스러워 보일까요?

2.아래는 텍스트 필드에 배경 깔아봤을 때 입니다. 
<img width="421" alt="스크린샷 2025-05-14 오후 11 47 30" src="https://github.com/user-attachments/assets/c700e3cd-eeb8-4f0e-9919-112b30fb0520" />

현재는 배경 안깔아놨습니다. 보시고 텍스트 필드에 배경을 넣을지 안넣을지 의견주시면 감사하겠습니다! 
