### PR TITLE
feat: 기본 데이터 및 온보딩 띄우기를 위한 로직 구현

### DIFF
--- a/Retrospective/Core/Storage/AppStorage/AppStorageKeys.swift
+++ b/Retrospective/Core/Storage/AppStorage/AppStorageKeys.swift
@@ -11,5 +11,12 @@ struct AppStorageKeys { }
 
 /// 프로젝트 전반에서 사용할 AppStorageKey를 정의하는 확장입니다.
 extension AppStorageKeys {
-    var example: AppStorageKey<Bool> { .init("example", defaultValue: true) }
+    /// 앱 첫 실행 시 초기 데이터를 로드했는지 여부를 나타내는 저장 키입니다.
+    var hasLoadedInitialData: AppStorageKey<Bool> {
+        .init("hasLoadedInitialData_v1", defaultValue: false)
+    }
+    /// 앱 첫 실행 시 온보딩을 완료했는지 여부를 나타내는 저장 키입니다.
+    var hasCompletedOnboarding: AppStorageKey<Bool> {
+        .init("hasCompletedOnboarding_v1", defaultValue: false)
+    }
 }

--- a/Retrospective/Core/Storage/SwiftData/PersistenceManager.swift
+++ b/Retrospective/Core/Storage/SwiftData/PersistenceManager.swift
@@ -32,6 +32,17 @@ final class PersistenceManager {
             fatalError(error.localizedDescription)
         }
     }()
+
+
+    func createInitialCategories(completion: (() -> Void)? = nil) {
+        let categories = [Category(name: "카테고리 1", color: .red),
+                          Category(name: "카테고리 2", color: .blue),
+                          Category(name: "카테고리 3", color: .yellow),
+                          Category(name: "카테고리 4", color: .green),
+                          Category(name: "카테고리 5", color: .black)]
+        categories.forEach(mainContext.insert(andSave:))
+        completion?()
+    }
 }
 
 extension PersistenceManager {

--- a/Retrospective/RetrospectiveApp.swift
+++ b/Retrospective/RetrospectiveApp.swift
@@ -10,14 +10,34 @@ import SwiftData
 
 @main
 struct RetrospectiveApp: App {
+
+    @AppStorage(\.hasLoadedInitialData) private var hasLoadedInitialData: Bool
+    @AppStorage(\.hasCompletedOnboarding) private var hasCompletedOnboarding: Bool
+    @State private var isShowingOnboarding: Bool = false
     let persistenceManager = PersistenceManager()
 
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .onAppear {
+                    if !hasCompletedOnboarding {
+                        isShowingOnboarding = true
+                        hasCompletedOnboarding = true
+                    }
+
+                    if !hasLoadedInitialData {
+                        persistenceManager.createInitialCategories {
+                            hasLoadedInitialData = true
+                        }
+                    }
+                }
+                .sheet(isPresented: $isShowingOnboarding) {
+                    Text("온보딩 화면")
+                }
                 .dynamicTypeSize(.small ... .xxxLarge)
         }
-//        .modelContext(persistenceManager.mainContext)
-        .modelContainer(PersistenceManager.previewContainer)
+        .modelContext(persistenceManager.mainContext)
+//        .modelContainer(PersistenceManager.previewContainer)
     }
 }
+

--- a/Retrospective/Views/HomeView/HomeView.swift
+++ b/Retrospective/Views/HomeView/HomeView.swift
@@ -58,9 +58,6 @@ struct HomeView: View {
                 }
             }
             .background(Color.appLightPeach)
-            .floatingSheet(isPresented: $isPresentedFilterSelectView) {
-                FilterSelectView(filteringCategories: $filteringCategories, isPresentedFilterSelectView: $isPresentedFilterSelectView)
-            }
             .retrospectiveNavigationTitle("Home")
             .retrospectiveNavigationBarColor(.appLightPeach)
             .retrospectiveLeadingToolBar {

--- a/Retrospective/Views/StatisticsView/Components/CategoryChartsListView.swift
+++ b/Retrospective/Views/StatisticsView/Components/CategoryChartsListView.swift
@@ -45,7 +45,7 @@ extension CategoryChartsListView {
             }
 
         }
-        .padding(8)
+        .padding(.vertical, 12)
         .padding(.horizontal, 14)
         .cornerRadius(.background, radius: 8)
         .defaultShadow(.black.opacity(0.11))

--- a/Retrospective/Views/StatisticsView/StatisticsView.swift
+++ b/Retrospective/Views/StatisticsView/StatisticsView.swift
@@ -133,7 +133,7 @@ extension StatisticsView {
                 }
                 .foregroundStyle(.label)
             }
-            .padding(8)
+            .padding(.vertical, 12)
             .padding(.horizontal, 14)
             .cornerRadius(.background, radius: 8)
             .defaultShadow(.black.opacity(0.11))


### PR DESCRIPTION
## #️⃣ Related Issues

close #66 

## 📝 Task Details

* 앱을 최초 실행 시, 넣을 기본 카테고리 데이터 추가했습니다~ 

![Simulator Screenshot - iPhone 16 Pro - 2025-05-15 at 13 48 49](https://github.com/user-attachments/assets/cfec45fe-df42-41fe-99cb-267115253fef)
![Simulator Screenshot - iPhone 16 Pro - 2025-05-15 at 13 50 49](https://github.com/user-attachments/assets/ecaa8577-5acf-460b-910e-d2a7fc0beb23)

* 온보딩 화면을 위한 기본 로직도 추가했으니 화면만 넣으세용

### Screenshot (Optional)

## 💬 Review Requests (Optional)

> If there are specific areas you want the reviewer to focus on, please mention them.
